### PR TITLE
Bug fixes and improvements

### DIFF
--- a/src/dbus_bus_connection.erl
+++ b/src/dbus_bus_connection.erl
@@ -22,7 +22,8 @@
 
 -export([get_bus_id/1,
 	 connect/1,
-     connect/2]).
+     connect/2,
+     get_unique_name/1]).
 
 %% dbus_connection callbacks
 -export([close/1,
@@ -75,6 +76,7 @@ connect(#bus_id{}=BusId, ServiceReg) ->
 			{ok, DBus} ->
 			    ConnId = hello(DBus),
 			    ?debug("Hello connection id: ~p~n", [ConnId]),
+                dbus_peer_connection:set_unique_name(PConn, ConnId),
 			    dbus_peer_connection:set_controlling_process(PConn, DBus),
 			    {ok, {?MODULE, DBus}};
 			{error, Err} -> {error, Err}
@@ -108,6 +110,12 @@ call(Bus, Msg) ->            dbus_proxy:call(Bus, Msg).
 -spec cast({?MODULE, dbus_connection()} | dbus_connection(), dbus_message()) -> ok | {error, term()}.
 cast({?MODULE, Bus}, Msg) -> dbus_proxy:cast(Bus, Msg);
 cast(Bus, Msg) ->            dbus_proxy:cast(Bus, Msg).
+
+%% @doc Get the DBUS connection unique name.
+%% @end
+-spec get_unique_name({?MODULE, dbus_connection()} | dbus_connection()) -> {ok, binary()} | {error, term()}.
+get_unique_name({?MODULE, Bus}) -> dbus_proxy:get_unique_name(Bus);
+get_unique_name(Bus) ->            dbus_proxy:get_unique_name(Bus).
 
 %%%
 %%% Priv

--- a/src/dbus_peer_connection.erl
+++ b/src/dbus_peer_connection.erl
@@ -199,7 +199,7 @@ code_change(_OldVsn, _StateName, State, _Extra) ->
 handle_event(cast, {set_unique_name, Name}, _StateName, #state{}=State) ->
     {keep_state, State#state{unique_name=Name}};
 
-handle_event({call, From}, get_unique_name, _StateName, #state{unique_name=Name}=State) ->
+handle_event({call, From}, get_unique_name, _StateName, #state{unique_name=Name}) ->
     gen_statem:reply(From, {ok, Name}),
     keep_state_and_data;
 

--- a/src/dbus_proxy.erl
+++ b/src/dbus_proxy.erl
@@ -29,6 +29,7 @@
          connect_signal/4,
          connect_signal/6,
          has_interface/2,
+         get_unique_name/1,
          interface/2,
          children/1
         ]).
@@ -219,6 +220,12 @@ interface(Proxy, InterfaceName) ->
     end
 .
 
+%% @doc Get the DBUS connection unique name.
+%% @end
+-spec get_unique_name(Proxy :: dbus_proxy()) -> {ok, binary()} | {error, term()}.
+get_unique_name(Proxy) -> gen_server:call(Proxy, get_unique_name).
+
+
 %%
 %% gen_server callbacks
 %%
@@ -302,6 +309,10 @@ handle_call(children, _From, #state{node=#dbus_node{name=Name, elements=Children
              end,
     Paths = lists:map(fun (#dbus_node{name=ChildPath}) -> filename:join(Prefix, ChildPath) end, Children),
     {reply, Paths, State};
+
+handle_call(get_unique_name, _From, #state{conn={dbus_peer_connection, PConn}}=State) ->
+    Ret = dbus_peer_connection:get_unique_name(PConn),
+    {reply, Ret, State};
 
 handle_call({call, Msg}, _From, #state{conn=Conn}=State) ->
     Ret = dbus_connection:call(Conn, Msg),

--- a/src/dbus_service.erl
+++ b/src/dbus_service.erl
@@ -150,7 +150,7 @@ handle_method_call(<<"/">>, #dbus_message{}=Msg, Conn,
     case dbus_constants:to_atom(Member) of
 	'Introspect' ->
 	    Elements = lists:foldl(fun({Path, _}, Res) ->
-					   [$/ | PathStr] = atom_to_list(Path),
+					   [$/ | PathStr] = binary_to_list(Path),
 					   [#dbus_node{name=PathStr} | Res]
 				   end, [], Objects),
 	    Node = #dbus_node{name="/", elements=Elements},


### PR DESCRIPTION
This PR fixes a few bugs:
- `Path` inside `Introspect` should be a binary instead of an atom
- Marshaling an array of bytes (`{array, byte}`), when binary payload given: just use the binary, instead of converting the binary to a list of chars and marshal the list (perf issues with large binaries)
- On DBus `Hello` reply, store the unique name and allow later retrieving it
- Allow `ServiceReg` argument to be a PID, when creating a `dbus_connection_peer`
- in `dbus_service_reg` to route replies to the registered `ServiceName` when the `destination` header field supplies one; fallback to the default service if not.