### PR TITLE
auth external: Resolve current user to cookie

### DIFF
--- a/src/dbus_auth_external.erl
+++ b/src/dbus_auth_external.erl
@@ -10,6 +10,8 @@
 
 -module(dbus_auth_external).
 
+-include("dbus.hrl").
+
 -behaviour(dbus_auth).
 
 %% dbus_auth callbacks
@@ -39,6 +41,8 @@ challenge(_, _) ->
 get_cookie() ->
     case application:get_env(dbus, external_cookie) of
 	undefined -> ?cookie;
+	{ok, system_user} -> 
+			get_current_user_uid();
 	{ok, Val} when is_list(Val) ->
 	    list_to_binary(Val);
 	{ok, Val} when is_binary(Val) ->
@@ -46,3 +50,55 @@ get_cookie() ->
 	{ok, Val} when is_integer(Val) ->
 	    integer_to_binary(Val)
     end.
+
+get_current_user_uid() ->
+	?debug("Getting current USER env~n", []),
+	case os:getenv("USER") of
+			false ->
+					?debug("Missing USER env~n", []),
+					?cookie;
+			User ->
+					% list_to_binary(User)
+					resolve_user_name(User)
+	end.
+
+resolve_user_name(User) ->
+	?debug("Resolving uid for user ~s~n", [User]),
+	Cmd = io_lib:format("id -u ~s", [User]),
+	case run_command(Cmd) of
+		{0, Result} -> 
+			Uid = string:trim(Result),
+			?debug("Successfully resolved user ~s to uid ~s~n", [User, Uid]),
+			dbus_hex:encode(list_to_binary(Uid));
+		{1, Reason} ->
+			?debug("Failed to resolve user ~s to uid: ~s~n", [User, Reason]),
+			?cookie;
+		_ -> ?cookie
+	end.
+
+run_command(Command) ->
+	Opt = [stream, exit_status, use_stdio,
+			   stderr_to_stdout, in, eof],
+	P = open_port({spawn, Command}, Opt),
+	get_data(P, []).
+
+get_data(P, D) ->
+    receive
+	{P, {data, D1}} ->
+	    get_data(P, [D1|D]);
+	{P, eof} ->
+	    port_close(P),    
+	    receive
+		{P, {exit_status, N}} ->
+		    {N, normalize(lists:flatten(lists:reverse(D)))}
+	    end
+    end.
+
+normalize([$\r, $\n | Cs]) ->
+    [$\n | normalize(Cs)];
+normalize([$\r | Cs]) ->
+    [$\n | normalize(Cs)];
+normalize([C | Cs]) ->
+    [C | normalize(Cs)];
+normalize([]) ->
+    [].

--- a/src/dbus_auth_external.erl
+++ b/src/dbus_auth_external.erl
@@ -64,8 +64,11 @@ get_current_user_uid() ->
 
 resolve_user_name(User) ->
 	?debug("Resolving uid for user ~s~n", [User]),
-	Cmd = io_lib:format("id -u ~s", [User]),
-	case run_command(Cmd) of
+	Command = io_lib:format("id -u ~s", [User]),
+	Opts = [stream, exit_status, use_stdio,
+			   stderr_to_stdout, in, eof],
+  P = open_port({spawn, Command}, Opts),
+	case get_data(P, []) of
 		{0, Result} -> 
 			Uid = string:trim(Result),
 			?debug("Successfully resolved user ~s to uid ~s~n", [User, Uid]),
@@ -75,12 +78,6 @@ resolve_user_name(User) ->
 			?cookie;
 		_ -> ?cookie
 	end.
-
-run_command(Command) ->
-	Opt = [stream, exit_status, use_stdio,
-			   stderr_to_stdout, in, eof],
-	P = open_port({spawn, Command}, Opt),
-	get_data(P, []).
 
 get_data(P, D) ->
     receive


### PR DESCRIPTION
Currently, the connection to the unix socket fails when using External auth mech for any user that does not have the UID 1000
The reason is that the default cookie is set for UID 1000, and for example `root` user has UID 0 which fails the auth.

While there is the option to provide a different cookie via the `external_cookie` application env variable, this PR introduces the `system_user` value as a way of automatically attempting to determine the correct UID and set the hex-encoded cookie accordingly.

The steps are, somewhat similar to what session_sha1 mech does, but expanded:
- Fetch the OS `USER` env variable
- Attempt resolving the username to a UID using `id -u <user>` command
- If successful, hex encode that into a cookie
- If not successful, use the default `?cookie`

This way, by simply setting `application:set_env(dbus, external_cookie, system_user)` from any application that relies on `erlang-dbus`, the UID is resolved automatically or fails gracefully to the default.